### PR TITLE
Add null media check from master

### DIFF
--- a/dist/hls.js
+++ b/dist/hls.js
@@ -3393,11 +3393,6 @@ var BufferController = /** @class */ (function (_super) {
             return;
         }
 
-        if (!this.media) {
-          logger["logger"].error('flushLiveBackBuffer called without attaching media');
-          return;
-        }
-        
         var currentTime = this.media.currentTime;
         var sourceBuffer = this.sourceBuffer;
         var bufferTypes = Object.keys(sourceBuffer);

--- a/dist/hls.js
+++ b/dist/hls.js
@@ -3392,6 +3392,12 @@ var BufferController = /** @class */ (function (_super) {
         if (!isFinite(liveBackBufferLength) || liveBackBufferLength < 0) {
             return;
         }
+
+        if (!this.media) {
+          logger["logger"].error('flushLiveBackBuffer called without attaching media');
+          return;
+        }
+        
         var currentTime = this.media.currentTime;
         var sourceBuffer = this.sourceBuffer;
         var bufferTypes = Object.keys(sourceBuffer);
@@ -3625,8 +3631,7 @@ var BufferController = /** @class */ (function (_super) {
         try {
             if (sb.updating)
                 return false;
-            // tivo fix
-            // sb.remove(removeStart, removeEnd);
+            sb.remove(startOffset, endOffset);
             return true;
         }
         catch (error) {
@@ -11785,7 +11790,7 @@ var Hls = /** @class */ (function (_super) {
          * @type {string}
          */
         get: function () {
-            return "0.12.4.3-feature-v0-12-4-3-tivo-SNAPSHOT";
+            return "0.12.4.2-1412b60";
         },
         enumerable: true,
         configurable: true

--- a/src/controller/buffer-controller.js
+++ b/src/controller/buffer-controller.js
@@ -388,6 +388,11 @@ class BufferController extends EventHandler {
       return;
     }
 
+    if (!this.media) {
+      logger.error('flushLiveBackBuffer called without attaching media');
+      return;
+    }
+
     const currentTime = this.media.currentTime;
     const sourceBuffer = this.sourceBuffer;
     const bufferTypes = Object.keys(sourceBuffer);


### PR DESCRIPTION
Adds null media object check to flushBuffer

When the error: cannot set currentTime of null occurs, I typically get stitcher errors after that and the app freezes video or the app restarts. This may not fix that but this code exists in master and makes sense.